### PR TITLE
quick new comparison that takes the appended uuid into account

### DIFF
--- a/src/compare_csv.py
+++ b/src/compare_csv.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """
 Given two CSV files, compare the two files and return the differences between the two files.
 
@@ -282,9 +283,10 @@ def filename_with_uuid_compare(era_filename, scholaris_filename):
     # Check if the Scholaris filename starts with the ERA filename (before the UUID)
     if scholaris_filename.startswith(era_filename_without_type):
         # Ensure the Scholaris filename has a valid UUID appended after the base filename
-        suffix = scholaris_filename[
-            len(era_filename_without_type):
-        ]  # Extract the suffix
+        # Extract the suffix
+        # slices with "black" styling in PEP 8 and
+        # flake lint uses PEP 8 + PEP 257 thus tool flags spacing differently
+        suffix = scholaris_filename[len(era_filename_without_type) :]  # noqa: E203
         if suffix.startswith("_") and len(suffix.split(".")[0]) > 1:
             return True
 

--- a/src/compare_csv.py
+++ b/src/compare_csv.py
@@ -256,6 +256,37 @@ def collection_parent_compare(list1, list2):
 
     return list1_collection_ids == list2
 
+#
+def filename_with_uuid_compare(era_filename, scholaris_filename):
+    """
+    Compare filenames, allowing for Scholaris filenames to have a UUID appended.
+    Example:
+        ERA: a.pdf
+        Scholaris: a_uuid.pdf
+    """
+
+    logging.debug("%s ---- %s", era_filename, scholaris_filename)
+    print("%s ---- %s", era_filename, scholaris_filename)
+    if not era_filename or not scholaris_filename:
+        return False
+
+    # Remove any whitespace and compare the base filename
+    era_filename = era_filename.strip()
+    scholaris_filename = scholaris_filename.strip()
+
+    if scholaris_filename == era_filename:
+        return True
+
+    era_filename_without_type = era_filename.split(".")[0]
+    print(era_filename_without_type)
+    # Check if the Scholaris filename starts with the ERA filename (before the UUID)
+    if scholaris_filename.startswith(era_filename_without_type):
+        # Ensure the Scholaris filename has a valid UUID appended after the base filename
+        suffix = scholaris_filename[len(era_filename_without_type):]  # Extract the suffix
+        if suffix.startswith("_") and len(suffix.split(".")[0]) > 1:
+            return True
+
+    return False
 
 #
 def special_language_compare(row, key, value):
@@ -618,7 +649,7 @@ bitstream_columns_to_compare = {
     "comparison_types": {
         "name": {
             "columns": {"jupiter": "filename", "dspace": "bitstream.name"},
-            "comparison_function": string_compare_ignore_whitespace,
+            "comparison_function": filename_with_uuid_compare,
         },
         "checksum": {
             "columns": {

--- a/src/compare_csv.py
+++ b/src/compare_csv.py
@@ -256,6 +256,7 @@ def collection_parent_compare(list1, list2):
 
     return list1_collection_ids == list2
 
+
 #
 def filename_with_uuid_compare(era_filename, scholaris_filename):
     """
@@ -278,15 +279,17 @@ def filename_with_uuid_compare(era_filename, scholaris_filename):
         return True
 
     era_filename_without_type = era_filename.split(".")[0]
-    print(era_filename_without_type)
     # Check if the Scholaris filename starts with the ERA filename (before the UUID)
     if scholaris_filename.startswith(era_filename_without_type):
         # Ensure the Scholaris filename has a valid UUID appended after the base filename
-        suffix = scholaris_filename[len(era_filename_without_type):]  # Extract the suffix
+        suffix = scholaris_filename[
+            len(era_filename_without_type):
+        ]  # Extract the suffix
         if suffix.startswith("_") and len(suffix.split(".")[0]) > 1:
             return True
 
     return False
+
 
 #
 def special_language_compare(row, key, value):

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -146,16 +146,18 @@ def test_collection_parent_compare():
     assert compare.collection_parent_compare('["a/b"]', "['c']") is False
     assert compare.collection_parent_compare("[]", float("NaN")) is False
 
+
 def test_filename_with_uuid_compare():
     """
     Test the filename with uuid
     """
-    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf") == True
-    assert compare.filename_with_uuid_compare("a.pdf", "b.pdf") == False
-    assert compare.filename_with_uuid_compare("a.pdf", "a_12345.pdf") == True
-    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf_extra") == False
-    assert compare.filename_with_uuid_compare("a.pdf", None) == False
-    assert compare.filename_with_uuid_compare(None, "a_uuid.pdf") == False
+    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf") is True
+    assert compare.filename_with_uuid_compare("a.pdf", "b.pdf") is False
+    assert compare.filename_with_uuid_compare("a.pdf", "a_12345.pdf") is True
+    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf_extra") is False
+    assert compare.filename_with_uuid_compare("a.pdf", None) is False
+    assert compare.filename_with_uuid_compare(None, "a_uuid.pdf") is False
+
 
 def test_language_compare():
     """

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -146,6 +146,16 @@ def test_collection_parent_compare():
     assert compare.collection_parent_compare('["a/b"]', "['c']") is False
     assert compare.collection_parent_compare("[]", float("NaN")) is False
 
+def test_filename_with_uuid_compare():
+    """
+    Test the filename with uuid
+    """
+    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf") == True
+    assert compare.filename_with_uuid_compare("a.pdf", "b.pdf") == False
+    assert compare.filename_with_uuid_compare("a.pdf", "a_12345.pdf") == True
+    assert compare.filename_with_uuid_compare("a.pdf", "a.pdf_extra") == False
+    assert compare.filename_with_uuid_compare("a.pdf", None) == False
+    assert compare.filename_with_uuid_compare(None, "a_uuid.pdf") == False
 
 def test_language_compare():
     """


### PR DESCRIPTION
During SAF package creation, if a bitstream filename was duplicated then an identifier was added (e.g., a.pdf ==> `a_uuid.pdf`` thus a direct comparison from ERA to Scholaris on the filename fails.